### PR TITLE
Add ShipAI.today to React & Next.js section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,7 @@ Production-ready, open source templates for building software-as-a-service appli
 - [Open SaaS -- React/Node.js/Prisma](https://opensaas.sh) - Stripe, Polar.sh, or Lemon Squeezy, OpenAI API app examples, AWS S3 file upload, Admin dashboard, & Blog w/ Astro.
 - [Next.js SaaS Starter](https://github.com/nextjs/saas-starter) - Get started quickly with Next.js, Postgres, Stripe, and shadcn/ui.
 - [Next.js Boilerplate](https://github.com/ixartz/Next-js-Boilerplate) - Free and open source Next.js starter.
+- [ShipAI.today](https://shipai.today/) - Next.js AI SaaS boilerplate with auth and billing.
 - [Nextacular](https://github.com/nextacular/nextacular) - Next.js SaaS boilerplate.
 - [fireact.dev](https://fireact.dev) - React/Typescript stack with Stripe, Firebase and i18n multilingual for B2B SaaS.
 - [Platforms Starter Kit](https://github.com/vercel/platforms) - The all-in-one starter kit for building multi-tenant applications.


### PR DESCRIPTION
## Summary
Add ShipAI.today to the React and Next.js section.

## Boilerplate
- Name: ShipAI.today
- Website: https://shipai.today/
- Tagline: AI SaaS Boilerplate and Next.js Launch Template
- Pricing: 299 USD one-time
- Affiliate Program: Yes

## Note
ShipAI.today is a commercial, source-included boilerplate. If this list only accepts OSI-licensed entries, I can move or remove this entry.
